### PR TITLE
Disabled 'Press Control for more Info'

### DIFF
--- a/config/actuallyadditions.cfg
+++ b/config/actuallyadditions.cfg
@@ -440,7 +440,7 @@ other {
     I:"Advanced Info NBT Character Limit"=1000
 
     # Show the 'Press Control for more Info'-Text on Item Tooltips
-    B:"Advanced Info Tooltips"=true
+    B:"Advanced Info Tooltips"=false
 
     # Should the entire text of the booklet be put into a new file in the Minecraft Folder on startup or resource reload. This is for debug purposes only and shouldn't really ever be needed.
     B:"Booklet Text to File"=false


### PR DESCRIPTION
Changed: Remove actuallyadditions 'Press Control for more Info', CTRL still works though.
